### PR TITLE
#1 Vagrant developer environment

### DIFF
--- a/vagrant/.gitignore
+++ b/vagrant/.gitignore
@@ -1,0 +1,3 @@
+.vagrant
+ssl
+*.log

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -1,0 +1,22 @@
+# Kubernetes Cluster with Vagrant on CoreOS
+
+This code copied from [coreos-kubernetes repository](https://github.com/coreos/coreos-kubernetes.git).
+
+View the [full instructions](https://coreos.com/kubernetes/docs/latest/kubernetes-on-vagrant.html).
+
+This deploy as simple as `vagrant up`.
+
+Grab `kubectl` like this:
+```
+# Linux
+curl -O https://storage.googleapis.com/kubernetes-release/release/v1.2.2/bin/linux/amd64/kubectl
+# or MacOS X
+curl -O https://storage.googleapis.com/kubernetes-release/release/v1.2.2/bin/darwin/amd64/kubectl
+
+chmod +x kubectl
+mv kubectl /usr/local/bin/kubectl
+```
+
+* View cluster status: `scripts/cluster_status.sh`.
+* Use this cluster as default for local kubectl: `eval $(bash scripts/cluster_use.sh)`.
+

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -1,0 +1,199 @@
+# -*- mode: ruby -*-
+# # vi: set ft=ruby :
+
+require 'fileutils'
+require 'open-uri'
+require 'tempfile'
+require 'yaml'
+
+Vagrant.require_version ">= 1.6.0"
+
+$update_channel = "alpha"
+$controller_count = 1
+$controller_vm_memory = 512
+$worker_count = 1
+$worker_vm_memory = 1024
+$etcd_count = 1
+$etcd_vm_memory = 512
+
+CONFIG = File.expand_path("config.rb")
+if File.exist?(CONFIG)
+  require CONFIG
+end
+
+if $worker_vm_memory < 1024
+  puts "Workers should have at least 1024 MB of memory"
+end
+
+CONTROLLER_CLUSTER_IP="10.3.0.1"
+
+ETCD_CLOUD_CONFIG_PATH = File.expand_path("etcd-cloud-config.yaml")
+
+CONTROLLER_CLOUD_CONFIG_PATH = File.expand_path("scripts/controller-install.sh")
+WORKER_CLOUD_CONFIG_PATH = File.expand_path("scripts/worker-install.sh")
+
+def etcdIP(num)
+  return "172.17.4.#{num+50}"
+end
+
+def controllerIP(num)
+  return "172.17.4.#{num+100}"
+end
+
+def workerIP(num)
+  return "172.17.4.#{num+200}"
+end
+
+controllerIPs = [*1..$controller_count].map{ |i| controllerIP(i) } <<  CONTROLLER_CLUSTER_IP
+etcdIPs = [*1..$etcd_count].map{ |i| etcdIP(i) }
+initial_etcd_cluster = etcdIPs.map.with_index{ |ip, i| "e#{i+1}=http://#{ip}:2380" }.join(",")
+etcd_endpoints = etcdIPs.map.with_index{ |ip, i| "http://#{ip}:2379" }.join(",")
+
+# Generate root CA
+system("mkdir -p ssl && bash scripts/init-ssl-ca ssl") or abort ("failed generating SSL artifacts")
+
+# Generate admin key/cert
+system("bash scripts/init-ssl ssl admin kube-admin") or abort("failed generating admin SSL artifacts")
+
+def provisionMachineSSL(machine,certBaseName,cn,ipAddrs)
+  tarFile = "ssl/#{cn}.tar"
+  ipString = ipAddrs.map.with_index { |ip, i| "IP.#{i+1}=#{ip}"}.join(",")
+  system("bash scripts/init-ssl ssl #{certBaseName} #{cn} #{ipString}") or abort("failed generating #{cn} SSL artifacts")
+  machine.vm.provision :file, :source => tarFile, :destination => "/tmp/ssl.tar"
+  machine.vm.provision :shell, :inline => "mkdir -p /etc/kubernetes/ssl && tar -C /etc/kubernetes/ssl -xf /tmp/ssl.tar", :privileged => true
+end
+
+Vagrant.configure("2") do |config|
+  # always use Vagrant's insecure key
+  config.ssh.insert_key = false
+
+  config.vm.box = "coreos-%s" % $update_channel
+  config.vm.box_version = ">= 766.0.0"
+  config.vm.box_url = "http://%s.release.core-os.net/amd64-usr/current/coreos_production_vagrant.json" % $update_channel
+
+  ["vmware_fusion", "vmware_workstation"].each do |vmware|
+    config.vm.provider vmware do |v, override|
+      override.vm.box_url = "http://%s.release.core-os.net/amd64-usr/current/coreos_production_vagrant_vmware_fusion.json" % $update_channel
+    end
+  end
+
+  config.vm.provider :virtualbox do |v|
+    # On VirtualBox, we don't have guest additions or a functional vboxsf
+    # in CoreOS, so tell Vagrant that so it can be smarter.
+    v.check_guest_additions = false
+    v.functional_vboxsf     = false
+  end
+
+  # plugin conflict
+  if Vagrant.has_plugin?("vagrant-vbguest") then
+    config.vbguest.auto_update = false
+  end
+
+  ["vmware_fusion", "vmware_workstation"].each do |vmware|
+    config.vm.provider vmware do |v|
+      v.vmx['numvcpus'] = 1
+      v.gui = false
+    end
+  end
+
+  config.vm.provider :virtualbox do |vb|
+    vb.cpus = 1
+    vb.gui = false
+  end
+
+  (1..$etcd_count).each do |i|
+    config.vm.define vm_name = "e%d" % i do |etcd|
+
+      data = YAML.load(IO.readlines(ETCD_CLOUD_CONFIG_PATH)[1..-1].join)
+      data['coreos']['etcd2']['initial-cluster'] = initial_etcd_cluster
+      data['coreos']['etcd2']['name'] = vm_name
+      etcd_config_file = Tempfile.new('etcd_config')
+      etcd_config_file.write("#cloud-config\n#{data.to_yaml}")
+      etcd_config_file.close
+
+      etcd.vm.hostname = vm_name
+
+      ["vmware_fusion", "vmware_workstation"].each do |vmware|
+        etcd.vm.provider vmware do |v|
+          v.vmx['memsize'] = $etcd_vm_memory
+        end
+      end
+
+      etcd.vm.provider :virtualbox do |vb|
+        vb.memory = $etcd_vm_memory
+      end
+
+      etcd.vm.network :private_network, ip: etcdIP(i)
+
+      etcd.vm.provision :file, :source => etcd_config_file.path, :destination => "/tmp/vagrantfile-user-data"
+      etcd.vm.provision :shell, :inline => "mv /tmp/vagrantfile-user-data /var/lib/coreos-vagrant/", :privileged => true
+    end
+  end
+
+
+  (1..$controller_count).each do |i|
+    config.vm.define vm_name = "c%d" % i do |controller|
+
+      env_file = Tempfile.new('env_file')
+      env_file.write("ETCD_ENDPOINTS=#{etcd_endpoints}\n")
+      env_file.close
+
+      controller.vm.hostname = vm_name
+
+      ["vmware_fusion", "vmware_workstation"].each do |vmware|
+        controller.vm.provider vmware do |v|
+          v.vmx['memsize'] = $controller_vm_memory
+        end
+      end
+
+      controller.vm.provider :virtualbox do |vb|
+        vb.memory = $controller_vm_memory
+      end
+
+      controllerIP = controllerIP(i)
+      controller.vm.network :private_network, ip: controllerIP
+
+      # Each controller gets the same cert
+      provisionMachineSSL(controller,"apiserver","kube-apiserver-#{controllerIP}",controllerIPs)
+
+      controller.vm.provision :file, :source => env_file, :destination => "/tmp/coreos-kube-options.env"
+      controller.vm.provision :shell, :inline => "mkdir -p /run/coreos-kubernetes && mv /tmp/coreos-kube-options.env /run/coreos-kubernetes/options.env", :privileged => true
+
+      controller.vm.provision :file, :source => CONTROLLER_CLOUD_CONFIG_PATH, :destination => "/tmp/vagrantfile-user-data"
+      controller.vm.provision :shell, :inline => "mv /tmp/vagrantfile-user-data /var/lib/coreos-vagrant/", :privileged => true
+    end
+  end
+
+  (1..$worker_count).each do |i|
+    config.vm.define vm_name = "w%d" % i do |worker|
+      worker.vm.hostname = vm_name
+
+      env_file = Tempfile.new('env_file')
+      env_file.write("ETCD_ENDPOINTS=#{etcd_endpoints}\n")
+      env_file.write("CONTROLLER_ENDPOINT=https://#{controllerIPs[0]}\n") #TODO(aaron): LB or DNS across control nodes
+      env_file.close
+
+      ["vmware_fusion", "vmware_workstation"].each do |vmware|
+        worker.vm.provider vmware do |v|
+          v.vmx['memsize'] = $worker_vm_memory
+        end
+      end
+
+      worker.vm.provider :virtualbox do |vb|
+        vb.memory = $worker_vm_memory
+      end
+
+      workerIP = workerIP(i)
+      worker.vm.network :private_network, ip: workerIP
+
+      provisionMachineSSL(worker,"worker","kube-worker-#{workerIP}",[workerIP])
+
+      worker.vm.provision :file, :source => env_file, :destination => "/tmp/coreos-kube-options.env"
+      worker.vm.provision :shell, :inline => "mkdir -p /run/coreos-kubernetes && mv /tmp/coreos-kube-options.env /run/coreos-kubernetes/options.env", :privileged => true
+
+      worker.vm.provision :file, :source => WORKER_CLOUD_CONFIG_PATH, :destination => "/tmp/vagrantfile-user-data"
+      worker.vm.provision :shell, :inline => "mv /tmp/vagrantfile-user-data /var/lib/coreos-vagrant/", :privileged => true
+    end
+  end
+
+end

--- a/vagrant/config.rb
+++ b/vagrant/config.rb
@@ -1,0 +1,11 @@
+$update_channel="alpha"
+
+$controller_count=1
+$controller_vm_memory=512
+
+$worker_count=3
+$worker_vm_memory=2048
+
+$etcd_count=1
+$etcd_vm_memory=512
+

--- a/vagrant/etcd-cloud-config.yaml
+++ b/vagrant/etcd-cloud-config.yaml
@@ -1,0 +1,19 @@
+#cloud-config
+
+coreos:
+  update:
+    reboot-strategy: "off"
+
+  etcd2:
+    name: {{ETCD_NODE_NAME}}
+    initial-cluster: {{ETCD_INITIAL_CLUSTER}}
+    advertise-client-urls: http://$private_ipv4:2379
+    listen-client-urls: http://0.0.0.0:2379
+    initial-advertise-peer-urls: http://$private_ipv4:2380
+    listen-peer-urls: http://$private_ipv4:2380
+
+  units:
+
+  - name: etcd2.service
+    command: start
+

--- a/vagrant/kubeconfig
+++ b/vagrant/kubeconfig
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    certificate-authority: ssl/ca.pem
+    server: https://172.17.4.101:443
+  name: vagrant-multi-cluster
+contexts:
+- context:
+    cluster: vagrant-multi-cluster
+    namespace: default
+    user: vagrant-multi-admin
+  name: vagrant-multi
+users:
+- name: vagrant-multi-admin
+  user:
+    client-certificate: ssl/admin.pem
+    client-key: ssl/admin-key.pem
+current-context: vagrant-multi

--- a/vagrant/scripts/cluster_status.sh
+++ b/vagrant/scripts/cluster_status.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+
+SCRIPT_DIR="$(dirname "$0")"
+
+export KUBECONFIG="${KUBECONFIG}:${SCRIPT_DIR}/../kubeconfig"
+
+kubectl config use-context vagrant-multi
+
+kubectl cluster-info
+

--- a/vagrant/scripts/cluster_use.sh
+++ b/vagrant/scripts/cluster_use.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+SCRIPT_DIR="$(dirname "$0")"
+
+cat <<TAGTAG
+export KUBECONFIG="\${KUBECONFIG}:${SCRIPT_DIR}/../kubeconfig" ;
+kubectl config use-context vagrant-multi ;
+TAGTAG
+

--- a/vagrant/scripts/cluster_use.sh
+++ b/vagrant/scripts/cluster_use.sh
@@ -5,7 +5,7 @@ set -e
 SCRIPT_DIR="$(dirname "$0")"
 
 cat <<TAGTAG
-export KUBECONFIG="\${KUBECONFIG}:${SCRIPT_DIR}/../kubeconfig" ;
+export KUBECONFIG="\${KUBECONFIG}:$(realpath ${SCRIPT_DIR}/../kubeconfig)" ;
 kubectl config use-context vagrant-multi ;
 TAGTAG
 

--- a/vagrant/scripts/controller-install.sh
+++ b/vagrant/scripts/controller-install.sh
@@ -1,0 +1,687 @@
+#!/bin/bash
+set -e
+
+# List of etcd servers (http://ip:port), comma separated
+export ETCD_ENDPOINTS=
+
+# Specify the version (vX.Y.Z) of Kubernetes assets to deploy
+export K8S_VER=v1.2.2_coreos.0
+
+# The CIDR network to use for pod IPs.
+# Each pod launched in the cluster will be assigned an IP out of this range.
+# Each node will be configured such that these IPs will be routable using the flannel overlay network.
+export POD_NETWORK=10.2.0.0/16
+
+# The CIDR network to use for service cluster IPs.
+# Each service will be assigned a cluster IP out of this range.
+# This must not overlap with any IP ranges assigned to the POD_NETWORK, or other existing network infrastructure.
+# Routing to these IPs is handled by a proxy service local to each node, and are not required to be routable between nodes.
+export SERVICE_IP_RANGE=10.3.0.0/24
+
+# The IP address of the Kubernetes API Service
+# If the SERVICE_IP_RANGE is changed above, this must be set to the first IP in that range.
+export K8S_SERVICE_IP=10.3.0.1
+
+# The IP address of the cluster DNS service.
+# This IP must be in the range of the SERVICE_IP_RANGE and cannot be the first IP in the range.
+# This same IP must be configured on all worker nodes to enable DNS service discovery.
+export DNS_SERVICE_IP=10.3.0.10
+
+# The above settings can optionally be overridden using an environment file:
+ENV_FILE=/run/coreos-kubernetes/options.env
+
+# -------------
+
+function init_config {
+    local REQUIRED=('ADVERTISE_IP' 'POD_NETWORK' 'ETCD_ENDPOINTS' 'SERVICE_IP_RANGE' 'K8S_SERVICE_IP' 'DNS_SERVICE_IP' 'K8S_VER' )
+
+    if [ -f $ENV_FILE ]; then
+        export $(cat $ENV_FILE | xargs)
+    fi
+
+    if [ -z $ADVERTISE_IP ]; then
+        export ADVERTISE_IP=$(awk -F= '/COREOS_PUBLIC_IPV4/ {print $2}' /etc/environment)
+    fi
+
+    for REQ in "${REQUIRED[@]}"; do
+        if [ -z "$(eval echo \$$REQ)" ]; then
+            echo "Missing required config value: ${REQ}"
+            exit 1
+        fi
+    done
+}
+
+function init_flannel {
+    echo "Waiting for etcd..."
+    while true
+    do
+        IFS=',' read -ra ES <<< "$ETCD_ENDPOINTS"
+        for ETCD in "${ES[@]}"; do
+            echo "Trying: $ETCD"
+            if [ -n "$(curl --silent "$ETCD/v2/machines")" ]; then
+                local ACTIVE_ETCD=$ETCD
+                break
+            fi
+            sleep 1
+        done
+        if [ -n "$ACTIVE_ETCD" ]; then
+            break
+        fi
+    done
+    RES=$(curl --silent -X PUT -d "value={\"Network\":\"$POD_NETWORK\",\"Backend\":{\"Type\":\"vxlan\"}}" "$ACTIVE_ETCD/v2/keys/coreos.com/network/config?prevExist=false")
+    if [ -z "$(echo $RES | grep '"action":"create"')" ] && [ -z "$(echo $RES | grep 'Key already exists')" ]; then
+        echo "Unexpected error configuring flannel pod network: $RES"
+    fi
+}
+
+function init_templates {
+    local TEMPLATE=/etc/systemd/system/kubelet.service
+    [ -f $TEMPLATE ] || {
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+[Service]
+ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
+
+Environment=KUBELET_VERSION=${K8S_VER}
+ExecStart=/usr/lib/coreos/kubelet-wrapper \
+  --api-servers=http://127.0.0.1:8080 \
+  --register-schedulable=false \
+  --allow-privileged=true \
+  --config=/etc/kubernetes/manifests \
+  --hostname-override=${ADVERTISE_IP} \
+  --cluster_dns=${DNS_SERVICE_IP} \
+  --cluster_domain=cluster.local
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+EOF
+    }
+
+    local TEMPLATE=/etc/kubernetes/manifests/kube-proxy.yaml
+    [ -f $TEMPLATE ] || {
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kube-proxy
+  namespace: kube-system
+spec:
+  hostNetwork: true
+  containers:
+  - name: kube-proxy
+    image: quay.io/coreos/hyperkube:$K8S_VER
+    command:
+    - /hyperkube
+    - proxy
+    - --master=http://127.0.0.1:8080
+    - --proxy-mode=iptables
+    securityContext:
+      privileged: true
+    volumeMounts:
+    - mountPath: /etc/ssl/certs
+      name: ssl-certs-host
+      readOnly: true
+  volumes:
+  - hostPath:
+      path: /usr/share/ca-certificates
+    name: ssl-certs-host
+EOF
+    }
+
+    local TEMPLATE=/etc/kubernetes/manifests/kube-apiserver.yaml
+    [ -f $TEMPLATE ] || {
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kube-apiserver
+  namespace: kube-system
+spec:
+  hostNetwork: true
+  containers:
+  - name: kube-apiserver
+    image: quay.io/coreos/hyperkube:$K8S_VER
+    command:
+    - /hyperkube
+    - apiserver
+    - --bind-address=0.0.0.0
+    - --etcd-servers=${ETCD_ENDPOINTS}
+    - --allow-privileged=true
+    - --service-cluster-ip-range=${SERVICE_IP_RANGE}
+    - --secure-port=443
+    - --advertise-address=${ADVERTISE_IP}
+    - --admission-control=NamespaceLifecycle,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota
+    - --tls-cert-file=/etc/kubernetes/ssl/apiserver.pem
+    - --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
+    - --client-ca-file=/etc/kubernetes/ssl/ca.pem
+    - --service-account-key-file=/etc/kubernetes/ssl/apiserver-key.pem
+    - --runtime-config=extensions/v1beta1/deployments=true,extensions/v1beta1/daemonsets=true
+    ports:
+    - containerPort: 443
+      hostPort: 443
+      name: https
+    - containerPort: 8080
+      hostPort: 8080
+      name: local
+    volumeMounts:
+    - mountPath: /etc/kubernetes/ssl
+      name: ssl-certs-kubernetes
+      readOnly: true
+    - mountPath: /etc/ssl/certs
+      name: ssl-certs-host
+      readOnly: true
+  volumes:
+  - hostPath:
+      path: /etc/kubernetes/ssl
+    name: ssl-certs-kubernetes
+  - hostPath:
+      path: /usr/share/ca-certificates
+    name: ssl-certs-host
+EOF
+    }
+
+    local TEMPLATE=/etc/kubernetes/manifests/kube-controller-manager.yaml
+    [ -f $TEMPLATE ] || {
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kube-controller-manager
+  namespace: kube-system
+spec:
+  containers:
+  - name: kube-controller-manager
+    image: quay.io/coreos/hyperkube:$K8S_VER
+    command:
+    - /hyperkube
+    - controller-manager
+    - --master=http://127.0.0.1:8080
+    - --leader-elect=true
+    - --service-account-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
+    - --root-ca-file=/etc/kubernetes/ssl/ca.pem
+    livenessProbe:
+      httpGet:
+        host: 127.0.0.1
+        path: /healthz
+        port: 10252
+      initialDelaySeconds: 15
+      timeoutSeconds: 1
+    volumeMounts:
+    - mountPath: /etc/kubernetes/ssl
+      name: ssl-certs-kubernetes
+      readOnly: true
+    - mountPath: /etc/ssl/certs
+      name: ssl-certs-host
+      readOnly: true
+  hostNetwork: true
+  volumes:
+  - hostPath:
+      path: /etc/kubernetes/ssl
+    name: ssl-certs-kubernetes
+  - hostPath:
+      path: /usr/share/ca-certificates
+    name: ssl-certs-host
+EOF
+    }
+
+    local TEMPLATE=/etc/kubernetes/manifests/kube-scheduler.yaml
+    [ -f $TEMPLATE ] || {
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kube-scheduler
+  namespace: kube-system
+spec:
+  hostNetwork: true
+  containers:
+  - name: kube-scheduler
+    image: quay.io/coreos/hyperkube:$K8S_VER
+    command:
+    - /hyperkube
+    - scheduler
+    - --master=http://127.0.0.1:8080
+    - --leader-elect=true
+    livenessProbe:
+      httpGet:
+        host: 127.0.0.1
+        path: /healthz
+        port: 10251
+      initialDelaySeconds: 15
+      timeoutSeconds: 1
+EOF
+    }
+
+    local TEMPLATE=/srv/kubernetes/manifests/kube-system.json
+    [ -f $TEMPLATE ] || {
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+{
+  "apiVersion": "v1",
+  "kind": "Namespace",
+  "metadata": {
+    "name": "kube-system"
+  }
+}
+EOF
+    }
+
+    local TEMPLATE=/srv/kubernetes/manifests/kube-dns-rc.json
+    [ -f $TEMPLATE ] || {
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+{
+  "apiVersion": "v1",
+  "kind": "ReplicationController",
+  "metadata": {
+    "labels": {
+      "k8s-app": "kube-dns",
+      "kubernetes.io/cluster-service": "true",
+      "version": "v11"
+    },
+    "name": "kube-dns-v11",
+    "namespace": "kube-system"
+  },
+  "spec": {
+    "replicas": 1,
+    "selector": {
+      "k8s-app": "kube-dns",
+      "version": "v11"
+    },
+    "template": {
+      "metadata": {
+        "labels": {
+          "k8s-app": "kube-dns",
+          "kubernetes.io/cluster-service": "true",
+          "version": "v11"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "command": [
+              "/usr/local/bin/etcd",
+              "-data-dir",
+              "/var/etcd/data",
+              "-listen-client-urls",
+              "http://127.0.0.1:2379,http://127.0.0.1:4001",
+              "-advertise-client-urls",
+              "http://127.0.0.1:2379,http://127.0.0.1:4001",
+              "-initial-cluster-token",
+              "skydns-etcd"
+            ],
+            "image": "gcr.io/google_containers/etcd-amd64:2.2.1",
+            "name": "etcd",
+            "resources": {
+              "limits": {
+                "cpu": "100m",
+                "memory": "500Mi"
+              },
+              "requests": {
+                "cpu": "100m",
+                "memory": "50Mi"
+              }
+            },
+            "volumeMounts": [
+              {
+                "mountPath": "/var/etcd/data",
+                "name": "etcd-storage"
+              }
+            ]
+          },
+          {
+            "args": [
+              "--domain=cluster.local"
+            ],
+            "image": "gcr.io/google_containers/kube2sky:1.14",
+            "livenessProbe": {
+              "failureThreshold": 5,
+              "httpGet": {
+                "path": "/healthz",
+                "port": 8080,
+                "scheme": "HTTP"
+              },
+              "initialDelaySeconds": 60,
+              "successThreshold": 1,
+              "timeoutSeconds": 5
+            },
+            "name": "kube2sky",
+            "readinessProbe": {
+              "httpGet": {
+                "path": "/readiness",
+                "port": 8081,
+                "scheme": "HTTP"
+              },
+              "initialDelaySeconds": 30,
+              "timeoutSeconds": 5
+            },
+            "resources": {
+              "limits": {
+                "cpu": "100m",
+                "memory": "200Mi"
+              },
+              "requests": {
+                "cpu": "100m",
+                "memory": "50Mi"
+              }
+            }
+          },
+          {
+            "args": [
+              "-machines=http://127.0.0.1:4001",
+              "-addr=0.0.0.0:53",
+              "-ns-rotate=false",
+              "-domain=cluster.local."
+            ],
+            "image": "gcr.io/google_containers/skydns:2015-10-13-8c72f8c",
+            "name": "skydns",
+            "ports": [
+              {
+                "containerPort": 53,
+                "name": "dns",
+                "protocol": "UDP"
+              },
+              {
+                "containerPort": 53,
+                "name": "dns-tcp",
+                "protocol": "TCP"
+              }
+            ],
+            "resources": {
+              "limits": {
+                "cpu": "100m",
+                "memory": "200Mi"
+              },
+              "requests": {
+                "cpu": "100m",
+                "memory": "50Mi"
+              }
+            }
+          },
+          {
+            "args": [
+              "-cmd=nslookup kubernetes.default.svc.cluster.local 127.0.0.1 >/dev/null",
+              "-port=8080"
+            ],
+            "image": "gcr.io/google_containers/exechealthz:1.0",
+            "name": "healthz",
+            "ports": [
+              {
+                "containerPort": 8080,
+                "protocol": "TCP"
+              }
+            ],
+            "resources": {
+              "limits": {
+                "cpu": "10m",
+                "memory": "20Mi"
+              },
+              "requests": {
+                "cpu": "10m",
+                "memory": "20Mi"
+              }
+            }
+          }
+        ],
+        "dnsPolicy": "Default",
+        "volumes": [
+          {
+            "emptyDir": {},
+            "name": "etcd-storage"
+          }
+        ]
+      }
+    }
+  }
+}
+EOF
+    }
+
+    local TEMPLATE=/srv/kubernetes/manifests/kube-dns-svc.json
+    [ -f $TEMPLATE ] || {
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+{
+  "apiVersion": "v1",
+  "kind": "Service",
+  "metadata": {
+    "name": "kube-dns",
+    "namespace": "kube-system",
+    "labels": {
+      "k8s-app": "kube-dns",
+      "kubernetes.io/name": "KubeDNS",
+      "kubernetes.io/cluster-service": "true"
+    }
+  },
+  "spec": {
+    "clusterIP": "$DNS_SERVICE_IP",
+    "ports": [
+      {
+        "protocol": "UDP",
+        "name": "dns",
+        "port": 53
+      },
+      {
+        "protocol": "TCP",
+        "name": "dns-tcp",
+        "port": 53
+      }
+    ],
+    "selector": {
+      "k8s-app": "kube-dns"
+    }
+  }
+}
+EOF
+    }
+
+    local TEMPLATE=/srv/kubernetes/manifests/heapster-dc.json
+    [ -f $TEMPLATE ] || {
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+{
+  "apiVersion": "extensions/v1beta1",
+  "kind": "Deployment",
+  "metadata": {
+    "labels": {
+      "k8s-app": "heapster",
+      "kubernetes.io/cluster-service": "true",
+      "version": "v1.0.2"
+    },
+    "name": "heapster-v1.0.2",
+    "namespace": "kube-system"
+  },
+  "spec": {
+    "replicas": 1,
+    "selector": {
+      "matchLabels": {
+        "k8s-app": "heapster",
+        "version": "v1.0.2"
+      }
+    },
+    "template": {
+      "metadata": {
+        "labels": {
+          "k8s-app": "heapster",
+          "version": "v1.0.2"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "command": [
+              "/heapster",
+              "--source=kubernetes.summary_api:''",
+              "--metric_resolution=60s"
+            ],
+            "image": "gcr.io/google_containers/heapster:v1.0.2",
+            "name": "heapster",
+            "resources": {
+              "limits": {
+                "cpu": "100m",
+                "memory": "250Mi"
+              },
+              "requests": {
+                "cpu": "100m",
+                "memory": "250Mi"
+              }
+            }
+          },
+          {
+            "command": [
+              "/pod_nanny",
+              "--cpu=100m",
+              "--extra-cpu=0m",
+              "--memory=250Mi",
+              "--extra-memory=4Mi",
+              "--threshold=5",
+              "--deployment=heapster-v1.0.2",
+              "--container=heapster",
+              "--poll-period=300000"
+            ],
+            "env": [
+              {
+                "name": "MY_POD_NAME",
+                "valueFrom": {
+                  "fieldRef": {
+                    "fieldPath": "metadata.name"
+                  }
+                }
+              },
+              {
+                "name": "MY_POD_NAMESPACE",
+                "valueFrom": {
+                  "fieldRef": {
+                    "fieldPath": "metadata.namespace"
+                  }
+                }
+              }
+            ],
+            "image": "gcr.io/google_containers/addon-resizer:1.0",
+            "name": "heapster-nanny",
+            "resources": {
+              "limits": {
+                "cpu": "50m",
+                "memory": "100Mi"
+              },
+              "requests": {
+                "cpu": "50m",
+                "memory": "100Mi"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+EOF
+    }
+
+    local TEMPLATE=/srv/kubernetes/manifests/heapster-svc.json
+    [ -f $TEMPLATE ] || {
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+{
+  "kind": "Service",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "heapster",
+    "namespace": "kube-system",
+    "labels": {
+      "kubernetes.io/cluster-service": "true",
+      "kubernetes.io/name": "Heapster"
+    }
+  },
+  "spec": {
+    "ports": [
+      {
+        "port": 80,
+        "targetPort": 8082
+      }
+    ],
+    "selector": {
+      "k8s-app": "heapster"
+    }
+  }
+}
+EOF
+    }
+
+    local TEMPLATE=/etc/flannel/options.env
+    [ -f $TEMPLATE ] || {
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+FLANNELD_IFACE=$ADVERTISE_IP
+FLANNELD_ETCD_ENDPOINTS=$ETCD_ENDPOINTS
+EOF
+    }
+
+    local TEMPLATE=/etc/systemd/system/flanneld.service.d/40-ExecStartPre-symlink.conf.conf
+    [ -f $TEMPLATE ] || {
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+[Service]
+ExecStartPre=/usr/bin/ln -sf /etc/flannel/options.env /run/flannel/options.env
+EOF
+    }
+
+    local TEMPLATE=/etc/systemd/system/docker.service.d/40-flannel.conf
+    [ -f $TEMPLATE ] || {
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+[Unit]
+Requires=flanneld.service
+After=flanneld.service
+EOF
+    }
+
+}
+
+function start_addons {
+    echo "Waiting for Kubernetes API..."
+    until curl --silent "http://127.0.0.1:8080/version"
+    do
+        sleep 5
+    done
+    echo
+    echo "K8S: kube-system namespace"
+    curl --silent -H "Content-Type: application/json" -XPOST -d"$(cat /srv/kubernetes/manifests/kube-system.json)" "http://127.0.0.1:8080/api/v1/namespaces" > /dev/null
+    echo "K8S: DNS addon"
+    curl --silent -H "Content-Type: application/json" -XPOST -d"$(cat /srv/kubernetes/manifests/kube-dns-rc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/replicationcontrollers" > /dev/null
+    curl --silent -H "Content-Type: application/json" -XPOST -d"$(cat /srv/kubernetes/manifests/kube-dns-svc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/services" > /dev/null
+    echo "K8S: Heapster addon"
+    curl --silent -H "Content-Type: application/json" -XPOST -d"$(cat /srv/kubernetes/manifests/heapster-dc.json)" "http://127.0.0.1:8080/apis/extensions/v1beta1/namespaces/kube-system/deployments" > /dev/null
+    curl --silent -H "Content-Type: application/json" -XPOST -d"$(cat /srv/kubernetes/manifests/heapster-svc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/services" > /dev/null
+}
+
+init_config
+init_templates
+
+init_flannel
+
+systemctl stop update-engine; systemctl mask update-engine
+
+systemctl daemon-reload
+systemctl enable kubelet; systemctl start kubelet
+start_addons
+echo "DONE"

--- a/vagrant/scripts/init-ssl
+++ b/vagrant/scripts/init-ssl
@@ -1,0 +1,72 @@
+#!/bin/bash -e
+
+# define location of openssl binary manually since running this
+# script under Vagrant fails on some systems without it
+OPENSSL=/usr/bin/openssl
+
+function usage {
+    echo "USAGE: $0 <output-dir> <cert-base-name> <CN> [SAN,SAN,SAN]"
+    echo "  example: $0 ./ssl/ worker kube-worker IP.1=127.0.0.1,IP.2=10.0.0.1"
+}
+
+if [ -z "$1" ] || [ -z "$2" ] || [ -z "$3" ]; then
+    usage
+    exit 1
+fi
+
+OUTDIR="$1"
+CERTBASE="$2"
+CN="$3"
+SANS="$4"
+
+if [ ! -d $OUTDIR ]; then
+    echo "ERROR: output directory does not exist:  $OUTDIR"
+    exit 1
+fi
+
+OUTFILE="$OUTDIR/$CN.tar"
+
+if [ -f "$OUTFILE" ];then
+    exit 0
+fi
+
+CNF_TEMPLATE="
+[req]
+req_extensions = v3_req
+distinguished_name = req_distinguished_name
+
+[req_distinguished_name]
+
+[ v3_req ]
+basicConstraints = CA:FALSE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+subjectAltName = @alt_names
+
+[alt_names]
+DNS.1 = kubernetes
+DNS.2 = kubernetes.default
+"
+echo "Generating SSL artifacts in $OUTDIR"
+
+
+CONFIGFILE="$OUTDIR/$CERTBASE-req.cnf"
+CAFILE="$OUTDIR/ca.pem"
+CAKEYFILE="$OUTDIR/ca-key.pem"
+KEYFILE="$OUTDIR/$CERTBASE-key.pem"
+CSRFILE="$OUTDIR/$CERTBASE.csr"
+PEMFILE="$OUTDIR/$CERTBASE.pem"
+
+CONTENTS="${CAFILE} ${KEYFILE} ${PEMFILE}"
+
+
+# Add SANs to openssl config
+echo "$CNF_TEMPLATE$(echo $SANS | tr ',' '\n')" > "$CONFIGFILE"
+
+$OPENSSL genrsa -out "$KEYFILE" 2048
+$OPENSSL req -new -key "$KEYFILE" -out "$CSRFILE" -subj "/CN=$CN" -config "$CONFIGFILE"
+$OPENSSL x509 -req -in "$CSRFILE" -CA "$CAFILE" -CAkey "$CAKEYFILE" -CAcreateserial -out "$PEMFILE" -days 365 -extensions v3_req -extfile "$CONFIGFILE"
+
+tar -cf $OUTFILE -C $OUTDIR $(for  f in $CONTENTS;do printf "$(basename $f) ";done)
+
+echo "Bundled SSL artifacts into $OUTFILE"
+echo "$CONTENTS"

--- a/vagrant/scripts/init-ssl-ca
+++ b/vagrant/scripts/init-ssl-ca
@@ -1,0 +1,34 @@
+#!/bin/bash -e
+
+# define location of openssl binary manually since running this
+# script under Vagrant fails on some systems without it
+OPENSSL=/usr/bin/openssl
+
+function usage {
+    echo "USAGE: $0 <output-dir>"
+    echo "  example: $0 ./ssl/ca.pem"
+}
+
+if [ -z "$1" ]; then
+    usage
+    exit 1
+fi
+
+OUTDIR="$1"
+
+if [ ! -d $OUTDIR ]; then
+    echo "ERROR: output directory does not exist:  $OUTDIR"
+    exit 1
+fi
+
+OUTFILE="$OUTDIR/ca.pem"
+
+if [ -f "$OUTFILE" ];then
+    exit 0
+fi
+
+# establish cluster CA and self-sign a cert
+$OPENSSL genrsa -out "$OUTDIR/ca-key.pem" 2048
+$OPENSSL req -x509 -new -nodes -key "$OUTDIR/ca-key.pem" -days 10000 -out "$OUTFILE" -subj "/CN=kube-ca"
+
+

--- a/vagrant/scripts/worker-install.sh
+++ b/vagrant/scripts/worker-install.sh
@@ -1,0 +1,182 @@
+#!/bin/bash
+set -e
+
+# List of etcd servers (http://ip:port), comma separated
+export ETCD_ENDPOINTS=
+
+# The endpoint the worker node should use to contact controller nodes (https://ip:port)
+# In HA configurations this should be an external DNS record or loadbalancer in front of the control nodes.
+# However, it is also possible to point directly to a single control node.
+export CONTROLLER_ENDPOINT=
+
+# Specify the version (vX.Y.Z) of Kubernetes assets to deploy
+export K8S_VER=v1.2.2_coreos.0
+
+# The IP address of the cluster DNS service.
+# This must be the same DNS_SERVICE_IP used when configuring the controller nodes.
+export DNS_SERVICE_IP=10.3.0.10
+
+# The above settings can optionally be overridden using an environment file:
+ENV_FILE=/run/coreos-kubernetes/options.env
+
+# -------------
+
+function init_config {
+    local REQUIRED=( 'ADVERTISE_IP' 'ETCD_ENDPOINTS' 'CONTROLLER_ENDPOINT' 'DNS_SERVICE_IP' 'K8S_VER' )
+
+    if [ -f $ENV_FILE ]; then
+        export $(cat $ENV_FILE | xargs)
+    fi
+
+    if [ -z $ADVERTISE_IP ]; then
+        export ADVERTISE_IP=$(awk -F= '/COREOS_PUBLIC_IPV4/ {print $2}' /etc/environment)
+    fi
+
+    for REQ in "${REQUIRED[@]}"; do
+        if [ -z "$(eval echo \$$REQ)" ]; then
+            echo "Missing required config value: ${REQ}"
+            exit 1
+        fi
+    done
+}
+
+function init_templates {
+    local TEMPLATE=/etc/systemd/system/kubelet.service
+    [ -f $TEMPLATE ] || {
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+[Service]
+ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
+
+Environment=KUBELET_VERSION=${K8S_VER}
+ExecStart=/usr/lib/coreos/kubelet-wrapper \
+  --api-servers=${CONTROLLER_ENDPOINT} \
+  --register-node=true \
+  --allow-privileged=true \
+  --config=/etc/kubernetes/manifests \
+  --hostname-override=${ADVERTISE_IP} \
+  --cluster_dns=${DNS_SERVICE_IP} \
+  --cluster_domain=cluster.local \
+  --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml \
+  --tls-cert-file=/etc/kubernetes/ssl/worker.pem \
+  --tls-private-key-file=/etc/kubernetes/ssl/worker-key.pem
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+EOF
+    }
+
+    local TEMPLATE=/etc/kubernetes/worker-kubeconfig.yaml
+    [ -f $TEMPLATE ] || {
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+apiVersion: v1
+kind: Config
+clusters:
+- name: local
+  cluster:
+    certificate-authority: /etc/kubernetes/ssl/ca.pem
+users:
+- name: kubelet
+  user:
+    client-certificate: /etc/kubernetes/ssl/worker.pem
+    client-key: /etc/kubernetes/ssl/worker-key.pem
+contexts:
+- context:
+    cluster: local
+    user: kubelet
+  name: kubelet-context
+current-context: kubelet-context
+EOF
+    }
+
+    local TEMPLATE=/etc/kubernetes/manifests/kube-proxy.yaml
+    [ -f $TEMPLATE ] || {
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kube-proxy
+  namespace: kube-system
+spec:
+  hostNetwork: true
+  containers:
+  - name: kube-proxy
+    image: quay.io/coreos/hyperkube:$K8S_VER
+    command:
+    - /hyperkube
+    - proxy
+    - --master=${CONTROLLER_ENDPOINT}
+    - --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml
+    - --proxy-mode=iptables
+    securityContext:
+      privileged: true
+    volumeMounts:
+      - mountPath: /etc/ssl/certs
+        name: "ssl-certs"
+      - mountPath: /etc/kubernetes/worker-kubeconfig.yaml
+        name: "kubeconfig"
+        readOnly: true
+      - mountPath: /etc/kubernetes/ssl
+        name: "etc-kube-ssl"
+        readOnly: true
+  volumes:
+    - name: "ssl-certs"
+      hostPath:
+        path: "/usr/share/ca-certificates"
+    - name: "kubeconfig"
+      hostPath:
+        path: "/etc/kubernetes/worker-kubeconfig.yaml"
+    - name: "etc-kube-ssl"
+      hostPath:
+        path: "/etc/kubernetes/ssl"
+EOF
+    }
+
+    local TEMPLATE=/etc/flannel/options.env
+    [ -f $TEMPLATE ] || {
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+FLANNELD_IFACE=$ADVERTISE_IP
+FLANNELD_ETCD_ENDPOINTS=$ETCD_ENDPOINTS
+EOF
+    }
+
+    local TEMPLATE=/etc/systemd/system/flanneld.service.d/40-ExecStartPre-symlink.conf.conf
+    [ -f $TEMPLATE ] || {
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+[Service]
+ExecStartPre=/usr/bin/ln -sf /etc/flannel/options.env /run/flannel/options.env
+EOF
+    }
+
+    local TEMPLATE=/etc/systemd/system/docker.service.d/40-flannel.conf
+    [ -f $TEMPLATE ] || {
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+[Unit]
+Requires=flanneld.service
+After=flanneld.service
+EOF
+    }
+
+}
+
+init_config
+init_templates
+
+systemctl stop update-engine; systemctl mask update-engine
+
+systemctl daemon-reload
+systemctl enable kubelet; systemctl start kubelet
+


### PR DESCRIPTION
Vagrantfile with some deps, which provides fully-functional k8s cluster. Unfortunately it uses coreos-alpha version (for kubernetes-wrapper script), and k8s controller runs in rkt. I think it's fine. Also here we have some nice features: Heapster, KubeDNS.

Unfortunately it's very resource hungry. I think in future we must get rid of etcd and controller nodes and run those on local docker.
