### PR TITLE
Move registry to kube-system namespace and add wait for running pod

### DIFF
--- a/registry/k8s/replication-controller.yaml
+++ b/registry/k8s/replication-controller.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ReplicationController
 metadata:
   name: kube-registry-v0
+  namespace: kube-system
   labels:
     k8s-app: kube-registry
     version: v0

--- a/registry/k8s/service.yaml
+++ b/registry/k8s/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: kube-registry
+  namespace: kube-system
   labels:
     k8s-app: kube-registry
     kubernetes.io/cluster-service: "true"

--- a/registry/scripts/start-registry.sh
+++ b/registry/scripts/start-registry.sh
@@ -5,8 +5,19 @@ SCRIPT_DIR="$(dirname "$0")"
 kubectl create -f $SCRIPT_DIR/../k8s/service.yaml
 kubectl create -f $SCRIPT_DIR/../k8s/replication-controller.yaml
 
-POD=$(kubectl get pods -l k8s-app=kube-registry \
+echo -n 'Waiting for pod (Interrupt with Control-C)'
+
+while true; do
+    echo -n '.'
+    POD=$(kubectl get pods --namespace=kube-system -l k8s-app=kube-registry \
             -o template --template '{{range .items}}{{.metadata.name}} {{.status.phase}}{{"\n"}}{{end}}' \
             | grep Running | head -1 | cut -f1 -d' ')
+    if [[ -n "$POD" ]]; then
+        echo "Got pod $POD"
+        break
+    fi
+    sleep 1
+done
 
-kubectl port-forward $POD 5000:5000
+kubectl port-forward $POD 5000:5000 2>&1 | logger &
+


### PR DESCRIPTION
1. If pod creation is slow (like vagrant dev env) `start-registry.sh` will fail. I added wait cycle.
2. Now KubeRegistry available as cluster addon:

```
$ kubectl cluster-info
Kubernetes master is running at https://172.17.4.101:443
Heapster is running at https://172.17.4.101:443/api/v1/proxy/namespaces/kube-system/services/heapster
KubeDNS is running at https://172.17.4.101:443/api/v1/proxy/namespaces/kube-system/services/kube-dns
KubeRegistry is running at https://172.17.4.101:443/api/v1/proxy/namespaces/kube-system/services/kube-registry
```
