### PR TITLE
Revert adding kube-system namespace...

### DIFF
--- a/registry/k8s/namespace.yaml
+++ b/registry/k8s/namespace.yaml
@@ -1,4 +1,0 @@
-kind: Namespace
-apiVersion: v1
-metadata:
-  name: kube-system


### PR DESCRIPTION
, because make -C registry restart kills everything

I'm sorry, but this is system namespace and it should be already created. With single-machine docker it must be created somewhere like `tools/k8s-docker.sh`.
