### PR TITLE
Fix liveness probe

### DIFF
--- a/cassandra/image-cassandra/rootfs/opt/yagoda/bin/cassandra-check
+++ b/cassandra/image-cassandra/rootfs/opt/yagoda/bin/cassandra-check
@@ -26,7 +26,7 @@ function exit_with_status() {
 
 
 function check_cassandra_is_ready() {
-	local host_ip=$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)
+	local host_ip=$(hostname --ip-address)
 	if [[ -z $host_ip ]]; then
 		exit_with_status "Can't get node ip address." "$STATUS_UNKNOWN"
 	fi


### PR DESCRIPTION
K8S inter-worker in vagrant is not eth0, but eth1. Either way cassandra image using `hostname --ip-address` for determining proper address, so let's do same thing in probe script.
resolves #44 
